### PR TITLE
Add replay counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ def TestDeploy(self):
         calls="projects.locations.functions",
         parent_schema="projects/{project_id}/locations/{location_id}",
     )
-    
+
     cloudfunction_client.execute(
         "get", parent_key="name", parent_schema="projects/{project_id}/locations/{location_id}/functions/{name}"
     )
@@ -75,7 +75,7 @@ Running your test will record all responses that your Client makes
 Now you can run your tests with `G_HTTP_TEST` with `REPLAY`. You can access the responses with `get_responses` or `get_response`
 
 ```python
-from goblet_gcp_client import get_responses, get_response
+from goblet_gcp_client import get_responses, get_response, get_replay_count
 
 def TestDeploy(self):
 
@@ -95,6 +95,7 @@ def TestDeploy(self):
     responses = get_responses("TEST_NAME")
     assert len(responses) == 2
     assert "test_value" in responses[0]["body"]
+    assert get_replay_count() == 1
 ```
 
 ## Features

--- a/goblet_gcp_client/__init__.py
+++ b/goblet_gcp_client/__init__.py
@@ -1,2 +1,2 @@
 from goblet_gcp_client.client import Client  # noqa: F401
-from goblet_gcp_client.http_files import get_response, get_responses  # noqa: F401
+from goblet_gcp_client.http_files import get_response, get_responses, get_replay_count  # noqa: F401

--- a/goblet_gcp_client/__version__.py
+++ b/goblet_gcp_client/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 1, 0)
+VERSION = (0, 1, 1)
 
 
 __version__ = ".".join(map(str, VERSION))

--- a/goblet_gcp_client/http_files.py
+++ b/goblet_gcp_client/http_files.py
@@ -2,7 +2,7 @@ import bz2
 import json
 import re
 
-from os import listdir, getenv, makedirs
+from os import listdir, getenv, makedirs, environ
 from os.path import join, exists, dirname, isdir
 
 from httplib2 import Http, Response
@@ -136,6 +136,9 @@ class HttpReplay(HttpFiles):
         redirections=1,
         connection_type=None,
     ):
+        # Increment G_REPLAY_COUNT
+        environ["G_REPLAY_COUNT"] = str(int(environ.get("G_REPLAY_COUNT", "0")) + 1)
+        
         if (method, uri) in self.static_responses:
             return (
                 Response(
@@ -158,6 +161,8 @@ class HttpReplay(HttpFiles):
                 self._cache[fpath] = response, serialized
             return response, serialized
 
+def get_replay_count():
+    return int(getenv("G_REPLAY_COUNT", 0))
 
 def get_responses(folder):
     """Get responses from the DATA_DIR for validating tests"""


### PR DESCRIPTION
`get_replay_count` returns the files replayed by the HTTP Replay class during the test (closes #3 )