### PR TITLE
query metadata.google.internal/computeMetadata/v1/instance/region to get region

### DIFF
--- a/goblet_gcp_client/__init__.py
+++ b/goblet_gcp_client/__init__.py
@@ -1,2 +1,6 @@
 from goblet_gcp_client.client import Client  # noqa: F401
-from goblet_gcp_client.http_files import get_response, get_responses, get_replay_count  # noqa: F401
+from goblet_gcp_client.http_files import (  # noqa: F401
+    get_response,
+    get_responses,
+    get_replay_count,
+)

--- a/goblet_gcp_client/client.py
+++ b/goblet_gcp_client/client.py
@@ -7,6 +7,12 @@ from google.api_core.client_options import ClientOptions
 from googleapiclient.discovery import build
 from goblet_gcp_client.http_files import HttpRecorder, HttpReplay, DATA_DIR
 from googleapiclient.errors import UnknownApiNameOrVersion
+import requests
+
+import logging
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
 
 
 def get_default_project():
@@ -24,8 +30,6 @@ def get_default_project():
         except Exception:
             return None
 
-    return None
-
 
 def get_default_location():
     for k in (
@@ -41,7 +45,14 @@ def get_default_location():
         if k in os.environ:
             return os.environ[k]
 
-    return None
+    try:
+        response = requests.get(
+            "http://metadata.google.internal/computeMetadata/v1/instance/region",
+            headers={"Metadata-Flavor": "Google"},
+        )
+        return response.text.strip().split("/")[-1]
+    except Exception:
+        return None
 
 
 def get_credentials():

--- a/goblet_gcp_client/http_files.py
+++ b/goblet_gcp_client/http_files.py
@@ -138,7 +138,7 @@ class HttpReplay(HttpFiles):
     ):
         # Increment G_REPLAY_COUNT
         environ["G_REPLAY_COUNT"] = str(int(environ.get("G_REPLAY_COUNT", "0")) + 1)
-        
+
         if (method, uri) in self.static_responses:
             return (
                 Response(
@@ -161,14 +161,17 @@ class HttpReplay(HttpFiles):
                 self._cache[fpath] = response, serialized
             return response, serialized
 
+
 def get_replay_count():
     """Returns the number of replays for a given test. Before running a test you run reset_replay_count"""
     return int(getenv("G_REPLAY_COUNT", 0))
 
+
 def reset_replay_count():
     """Resets the replay file count. It is best to run before executing a new set of tests"""
     environ["G_REPLAY_COUNT"] = "0"
-    return 
+    return
+
 
 def get_responses(folder):
     """Get responses from the DATA_DIR for validating tests"""

--- a/goblet_gcp_client/tests/test_client.py
+++ b/goblet_gcp_client/tests/test_client.py
@@ -6,6 +6,17 @@ class TestClient:
         monkeypatch.setenv("GOOGLE_PROJECT", "TEST")
         assert get_default_project() == "TEST"
 
-    def get_default_location(self, monkeypatch):
+    def test_get_default_location_environment_variable(self, monkeypatch, requests_mock):
         monkeypatch.setenv("GCLOUD_REGION", "TEST")
+        requests_mock.get(
+            "http://metadata.google.internal/computeMetadata/v1/instance/region",
+            text="us-central2",
+        )
         assert get_default_location() == "TEST"
+
+    def test_get_default_location_metadata_service(self, monkeypatch, requests_mock):
+        requests_mock.get(
+            "http://metadata.google.internal/computeMetadata/v1/instance/region",
+            text="us-central2",
+        )
+        assert get_default_location() == "us-central2"


### PR DESCRIPTION
get_default_location() first tries to get a location from a list of environment variables. 

if there is no environment variable set to provide a location, query the metadata service. 

any exception returns None