### PR TITLE
add missing requirement , enable testing workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           make lint
       - uses: psf/black@stable
         with:
-          src: "./goblet"
+          src: "./goblet_gcp_client"
           version: "23.1.0"
 
   Test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,59 @@
+name: "CI"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4 
+        with:
+          python-version: 3.8
+          cache: "pip"
+      - name: Install Linter
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+      - name: Lint Check
+        run: |
+          make lint
+      - uses: psf/black@stable
+        with:
+          src: "./goblet"
+          version: "23.1.0"
+
+  Test:
+    runs-on: ubuntu-latest
+    needs: Lint
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+    name: Test Python ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4 
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+      - name: Install pytest
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install coverage
+          pip install -r requirements.txt
+      - name: Run pytest
+        run: |
+          export PYTHONPATH=$(pwd)
+          export X_GOBLET_LOCAL=true
+          export G_MOCK_CREDENTIALS=True
+          coverage run -m pytest goblet_gcp_client/tests;
+      - name: "Upload coverage to Codecov"
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,12 +48,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest
           pip install coverage
+          pip install requests-mock
           pip install -r requirements.txt
       - name: Run pytest
         run: |
           export PYTHONPATH=$(pwd)
-          export X_GOBLET_LOCAL=true
           export G_MOCK_CREDENTIALS=True
+          export G_HTTP_TEST=REPLAY
           coverage run -m pytest goblet_gcp_client/tests;
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v1

--- a/goblet_gcp_client/__version__.py
+++ b/goblet_gcp_client/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 1, 7)
+VERSION = (0, 1, 8)
 
 
 __version__ = ".".join(map(str, VERSION))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 google-api-python-client==2.86.0
+six==1.16.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ DESCRIPTION = 'GCP Client and GCP integration testing helpers'
 URL = 'https://github.com/goblet/goblet_gcp_client'
 EMAIL = 'austen.novis@gmail.com'
 AUTHOR = 'Austen'
-REQUIRES_PYTHON = '>=3.7.0'
+REQUIRES_PYTHON = '>=3.8.0'
 VERSION = os.environ.get('VERSION')
 
 # What packages are required for this module to be executed?
@@ -102,10 +102,10 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ VERSION = os.environ.get('VERSION')
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    "google-api-python-client"
+    "google-api-python-client", "six"
 ]
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
ran into errors `ModuleNotFoundError: No module named 'six'` when running test cases locally and deploying goblet only relying on goblet-gcp dependencies. 

related to [line](https://github.com/goblet/goblet_gcp_client/blob/5575f83606875beed834165d892efa8894674cf4/goblet_gcp_client/http_files.py#L9)

adding six as required dependency to resolve this
added testing workflow to ensure testing is working as expected
drop python 3.7 support